### PR TITLE
Add parsing for California

### DIFF
--- a/lottery_data_scraper/california.py
+++ b/lottery_data_scraper/california.py
@@ -2,7 +2,6 @@ import locale
 import logging
 import json
 import operator
-import requests
 import html2text
 
 from lottery_data_scraper.schemas import GameSchema
@@ -12,13 +11,14 @@ from lottery_data_scraper.util import fetch_html
 # because California only gives prize values and our schema
 # expects a string representation of the prize.
 # https://docs.python.org/3/library/locale.html
-locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+locale.setlocale(locale.LC_ALL, "en_US.utf8")
 
 logger = logging.getLogger(__name__)
 h = html2text.HTML2Text()
 
 BASE_URL = "https://www.calottery.com"
 SCRATCHER_URL = "https://www.calottery.com/api/games/scratchers"
+
 
 def num_tx_initial(game):
     grand_prize = game["topPrizeTier"]
@@ -35,7 +35,9 @@ def fetch_games():
                 "available": prize_["numberOfPrizesPending"],
                 "claimed": prize_["numberOfPrizesCashed"],
                 "value": prize_["value"],
-                "prize": locale.currency(prize_["value"], grouping=True)[:-3] # -3 to drop the cents
+                "prize": locale.currency(prize_["value"], grouping=True)[
+                    :-3
+                ],  # -3 to drop the cents
             }
             prizes.append(prize)
         grand_prize = sorted(game_["prizeTiers"], key=operator.itemgetter("value"))[-1]

--- a/lottery_data_scraper/california.py
+++ b/lottery_data_scraper/california.py
@@ -47,7 +47,7 @@ def fetch_games():
             "desription": h.handle(game_["description"]),
             "image_urls": [game_["unScratchedImage"], game_["scratchedImage"]],
             "how_to_play": h.handle(game_["howToPlay"]),
-            "num_tx_initial": grand_prize["odds"] * grand_prize["totalNumberOfPrizes"],
+            "num_tx_initial": num_tx_initial(game_),
             "price": game_["price"],
             "prizes": prizes,
             "state": "tx",

--- a/lottery_data_scraper/california.py
+++ b/lottery_data_scraper/california.py
@@ -1,0 +1,59 @@
+import locale
+import logging
+import json
+import requests
+import html2text
+
+from lottery_data_scraper.schemas import GameSchema
+from lottery_data_scraper.util import fetch_html
+
+# Set local for currency conversion and formatting
+# because California only gives prize values and our schema
+# expects a string representation of the prize.
+# https://docs.python.org/3/library/locale.html
+locale.setlocale(locale.LC_ALL, 'en_US.utf8')
+
+logger = logging.getLogger(__name__)
+h = html2text.HTML2Text()
+
+BASE_URL = "https://www.calottery.com"
+SCRATCHER_URL = "https://www.calottery.com/api/games/scratchers"
+
+def num_tx_initial(game):
+    grand_prize = game["topPrizeTier"]
+    return grand_prize["odds"] * grand_prize["totalNumberOfPrizes"]
+
+
+def fetch_games():
+    response = json.loads(fetch_html(SCRATCHER_URL))
+    games = []
+    for game_ in response["games"]:
+        prizes = []
+        for prize_ in game_["prizeTiers"]:
+            prize = {
+                "available": prize_["numberOfPrizesPending"],
+                "claimed": prize_["numberOfPrizesCashed"],
+                "value": prize_["value"],
+                "prize": locale.currency(prize_["value"], grouping=True)[:-3] # -3 to drop the cents
+            }
+            prizes.append(prize)
+        game = {
+            "game_id": game_["gameNumber"],
+            "name": game_["name"],
+            "desription": h.handle(game_["description"]),
+            "image_urls": [game_["unScratchedImage"], game_["scratchedImage"]],
+            "how_to_play": h.handle(game_["howToPlay"]),
+            "num_tx_initial": sum(prize["available"] + prize["claimed"] for prize in prizes),
+            "price": game_["price"],
+            "prizes": prizes,
+            "state": "tx",
+            "url": BASE_URL + game_["productPage"],
+        }
+        games.append(game)
+    return games
+
+
+if __name__ == "__main__":
+    games = fetch_games()
+    schema = GameSchema(many=True)
+    print(schema.dumps(games))

--- a/lottery_data_scraper/california.py
+++ b/lottery_data_scraper/california.py
@@ -1,6 +1,7 @@
 import locale
 import logging
 import json
+import operator
 import requests
 import html2text
 
@@ -37,13 +38,14 @@ def fetch_games():
                 "prize": locale.currency(prize_["value"], grouping=True)[:-3] # -3 to drop the cents
             }
             prizes.append(prize)
+        grand_prize = sorted(game_["prizeTiers"], key=operator.itemgetter("value"))[-1]
         game = {
             "game_id": game_["gameNumber"],
             "name": game_["name"],
             "desription": h.handle(game_["description"]),
             "image_urls": [game_["unScratchedImage"], game_["scratchedImage"]],
             "how_to_play": h.handle(game_["howToPlay"]),
-            "num_tx_initial": sum(prize["available"] + prize["claimed"] for prize in prizes),
+            "num_tx_initial": grand_prize["odds"] * grand_prize["totalNumberOfPrizes"],
             "price": game_["price"],
             "prizes": prizes,
             "state": "tx",

--- a/tests/test_california.py
+++ b/tests/test_california.py
@@ -1,0 +1,12 @@
+import json
+import subprocess
+import unittest
+
+from lottery_data_scraper.util import fetch_html
+
+class TestCalifornia(unittest.TestCase):
+    def test_all(self):
+        result = subprocess.run(["python3", "-m", "lottery_data_scraper.california"], capture_output=True)
+        data = json.loads(result.stdout)
+        self.assertEqual(data[0]["game_id"], "1405", "Expected the first game to be PAC-MAN, #1405.")
+        self.assertEqual(data[0]["num_tx_initial"], 37080000, "Expected 37,080,000 tickets for PAC-MAN #1405.")

--- a/tests/test_california.py
+++ b/tests/test_california.py
@@ -2,11 +2,18 @@ import json
 import subprocess
 import unittest
 
-from lottery_data_scraper.util import fetch_html
 
 class TestCalifornia(unittest.TestCase):
     def test_all(self):
-        result = subprocess.run(["python3", "-m", "lottery_data_scraper.california"], capture_output=True)
+        result = subprocess.run(
+            ["python3", "-m", "lottery_data_scraper.california"], capture_output=True
+        )
         data = json.loads(result.stdout)
-        self.assertEqual(data[0]["game_id"], "1405", "Expected the first game to be PAC-MAN, #1405.")
-        self.assertEqual(data[0]["num_tx_initial"], 37080000, "Expected 37,080,000 tickets for PAC-MAN #1405.")
+        self.assertEqual(
+            data[0]["game_id"], "1405", "Expected the first game to be PAC-MAN, #1405."
+        )
+        self.assertEqual(
+            data[0]["num_tx_initial"],
+            37080000,
+            "Expected 37,080,000 tickets for PAC-MAN #1405.",
+        )


### PR DESCRIPTION
A good way to test these is to compare the numbers to what you see at https://scratchoff-odds.com.

In this case, looking at the pac-man game #1405 https://scratchoff-odds.com/state/ca/game/2168 I already see an error. I'm miscalculating the num_tx_initial. I'm adding up all of the prizes but I'm not taking into account the non-winning tickets. TODO: take into account the non-winning tickets.

In the output below, the number of tickets is `9,065,328` but at scratchoff-odds.com it's over 40,000,000.

```
(lottery_data_scraper) ➜  lottery_data_scraper git:(california) PY_LOG_LVL=debug python3 -m lottery_data_scraper.california | jq | head -n 50
2023-04-20 22:36:55,926 /home/eihli/.virtualenvs/lottery_data_scraper/lib/python3.10/site-packages/urllib3/connectionpool.py 1003 DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): www.calottery.com:443
2023-04-20 22:36:56,321 /home/eihli/.virtualenvs/lottery_data_scraper/lib/python3.10/site-packages/urllib3/connectionpool.py 456 DEBUG:urllib3.connectionpool:https://www.calottery.com:443 "GET /api/games/scratchers HTTP/1.1" 200 361988
[
  {
    "image_urls": "[\"https://static.www.calottery.com/-/media/Project/calottery/PWS/obsolete-scratchers-images-jan-1-2023/1405-2-Pac-Man-CV.png?rev=09f8bc5a134043318a05d94ad1efd74e\", \"https://static.www.calottery.com/-/media/Project/calottery/PWS/obsolete-scratchers-images-jan-1-2023/1405-2-Pac-Man-UC.png?rev=304be607fbfc46478110b84fb3f5ed9a\"]",
    "how_to_play": "\n  * Match any of \"YOUR NUMBERS\" to any of the three \"WINNING NUMBERS,\" win that prize.\n\n  * Uncover a \"PAC-MAN\" symbol to automatically win that prize.\n\n  * Uncover a \"2X\" symbol to automatically win 2 times that prize.\n\n  * Uncover a \"KEY\" symbol in the \"READY! BONUS,\" win $20 instantly!\n\n",
    "num_tx_initial": 9065328,
    "price": 2,
    "prizes": [
      {
        "prize": "$20,000",
        "claimed": 37,
        "available": 23,
        "value": 20000
      },
      {
        "prize": "$1,000",
        "claimed": 199,
        "available": 120,
        "value": 1000
      },
      {
        "prize": "$500",
        "claimed": 1686,
        "available": 815,
        "value": 500
      },
      {
        "prize": "$100",
        "claimed": 6741,
        "available": 3523,
        "value": 100
      },
      {
        "prize": "$50",
        "claimed": 41051,
        "available": 20602,
        "value": 50
      },
      {
        "prize": "$20",
        "claimed": 300480,
        "available": 163430,
        "value": 20
      },
      {
        "prize": "$10",
        "claimed": 714764,
        "available": 397775,
        "value": 10
      },
```